### PR TITLE
v0.0.6

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@
 
 * Could not use 'daisy' with sample rate setter.
 
+### New Features
+
+* Add function in utilities for making daisy packets.
+
 
 # 0.0.5
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,10 @@
+# 0.0.6
+
+### Bug Fixes
+
+* Could not use 'daisy' with sample rate setter.
+
+
 # 0.0.5
 
 ### Bug Fixes

--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,12 @@
 ### New Features
 
 * Add function in utilities for making daisy packets.
+* Add code to `getChannelDataArray` for ganglion and daisy data being routed over wifi
+* Create idea of protocols i.e. `BLE`, `Wifi`, and `Serial`
 
+### Breaking changes
+
+* `getChannelDataArray` now takes object as only arg.
 
 # 0.0.5
 

--- a/openBCIConstants.js
+++ b/openBCIConstants.js
@@ -1319,7 +1319,7 @@ function sampleRateSetter (boardType, sampleRate) {
     sampleRate = Math.floor(sampleRate);
 
     let func;
-    if (boardType === obciBoardCyton) {
+    if (boardType === obciBoardCyton || boardType === obciBoardDaisy) {
       func = commandSampleRateForCmdCyton;
     } else if (boardType === obciBoardGanglion) {
       func = commandSampleRateForCmdGanglion;

--- a/openBCIConstants.js
+++ b/openBCIConstants.js
@@ -230,8 +230,9 @@ const obciRadioCmdBaudRateSetFast = 0x06;
 const obciRadioCmdSystemStatus = 0x07;
 
 /** Possible number of channels */
+const obciNumberOfChannelsCyton = 8;
 const obciNumberOfChannelsDaisy = 16;
-const obciNumberOfChannelsDefault = 8;
+const obciNumberOfChannelsDefault = obciNumberOfChannelsCyton;
 const obciNumberOfChannelsGanglion = 4;
 
 /** Possible OpenBCI board types */
@@ -456,14 +457,14 @@ const obciGanglionPacket19Bit = {
   dataStart: 1,
   dataStop: 20
 };
-const obciGanglionMCP3912Gain = 1.0;  // assumed gain setting for MCP3912.  NEEDS TO BE ADJUSTABLE JM
+const obciGanglionMCP3912Gain = 51.0;  // assumed gain setting for MCP3912.  NEEDS TO BE ADJUSTABLE JM
 const obciGanglionMCP3912Vref = 1.2;  // reference voltage for ADC in MCP3912 set in hardware
 const obciGanglionPrefix = 'Ganglion';
 const obciGanglionSyntheticDataEnable = 't';
 const obciGanglionSyntheticDataDisable = 'T';
 const obciGanglionImpedanceStart = 'z';
 const obciGanglionImpedanceStop = 'Z';
-const obciGanglionScaleFactorPerCountVolts = obciGanglionMCP3912Vref / (8388607.0 * obciGanglionMCP3912Gain * 1.5 * 51.0);
+const obciGanglionScaleFactorPerCountVolts = obciGanglionMCP3912Vref / (8388607.0 * obciGanglionMCP3912Gain * 1.5);
 
 /** Simblee */
 const simbleeUuidService = 'fe84';
@@ -483,6 +484,11 @@ const obciNobleEmitterScanStart = 'scanStart';
 const obciNobleEmitterScanStop = 'scanStop';
 const obciNobleEmitterStateChange = 'stateChange';
 const obciNobleStatePoweredOn = 'poweredOn';
+
+/** Protocols */
+const obciProtocolBLE = "ble";
+const obciProtocolSerial = "serial";
+const obciProtocolWifi = "wifi";
 
 module.exports = {
   /** Turning channels off */
@@ -878,6 +884,7 @@ module.exports = {
   /** Triggers */
   OBCITrigger: obciTrigger,
   /** Possible number of channels */
+  OBCINumberOfChannelsCyton: obciNumberOfChannelsCyton,
   OBCINumberOfChannelsDaisy: obciNumberOfChannelsDaisy,
   OBCINumberOfChannelsDefault: obciNumberOfChannelsDefault,
   OBCINumberOfChannelsGanglion: obciNumberOfChannelsGanglion,
@@ -1170,7 +1177,11 @@ module.exports = {
   isPeripheralGanglion,
   commandSampleRateForCmdCyton,
   commandSampleRateForCmdGanglion,
-  commandBoardModeForMode
+  commandBoardModeForMode,
+  /** Protocols */
+  OBCIProtocolBLE: obciProtocolBLE,
+  OBCIProtocolSerial: obciProtocolSerial,
+  OBCIProtocolWifi: obciProtocolWifi
 };
 
 /**

--- a/openBCIConstants.js
+++ b/openBCIConstants.js
@@ -239,6 +239,7 @@ const obciBoardCyton = 'cyton';
 const obciBoardDaisy = 'daisy';
 const obciBoardDefault = 'default';
 const obciBoardGanglion = 'ganglion';
+const obciBoardNone = 'none';
 
 /** Possible Simulator Line Noise injections */
 const obciSimulatorLineNoiseHz60 = '60Hz';
@@ -885,12 +886,16 @@ module.exports = {
   OBCIBoardDaisy: obciBoardDaisy,
   OBCIBoardDefault: obciBoardDefault,
   OBCIBoardGanglion: obciBoardGanglion,
+  OBCIBoardNone: obciBoardNone,
   numberOfChannelsForBoardType: boardType => {
     switch (boardType) {
       case obciBoardDaisy:
         return obciNumberOfChannelsDaisy;
       case obciBoardGanglion:
         return obciNumberOfChannelsGanglion;
+      case obciBoardNone:
+        return 0;
+      case obciBoardCyton:
       default:
         return obciNumberOfChannelsDefault;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openbci-utilities",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "The official utility package of Node.js SDK for the OpenBCI Biosensor Boards.",
   "main": "index.js",
   "scripts": {

--- a/test/openBCIConstants-test.js
+++ b/test/openBCIConstants-test.js
@@ -1587,8 +1587,17 @@ describe('OpenBCIConstants', function () {
         done(err);
       });
     });
+    it('Works for daisy', function (done) {
+      k.getSampleRateSetter('daisy', 1000).then(function (arrayOfCommands) {
+        arrayOfCommands[0].should.equal('~');
+        arrayOfCommands[1].should.equal('4');
+        done();
+      }).catch(function (err) {
+        done(err);
+      });
+    });
     it('Invalid board type', function (done) {
-      k.getSampleRateSetter('daisy', 1600).should.be.rejected.and.notify(done);
+      k.getSampleRateSetter('taco', 1600).should.be.rejected.and.notify(done);
     });
     it('Invalid board type type', function (done) {
       k.getSampleRateSetter(10, 1600).should.be.rejected.and.notify(done);

--- a/test/openBCIConstants-test.js
+++ b/test/openBCIConstants-test.js
@@ -967,6 +967,34 @@ describe('OpenBCIConstants', function () {
       expect(k.OBCIRadioPollTimeMin).to.be.equal(0);
     });
   });
+  describe('Board Types', function () {
+    it('should get right name for chan daisy', function () {
+      expect(k.OBCIBoardDaisy).to.equal("daisy");
+    });
+    it('should get right name for chan cyton', function () {
+      expect(k.OBCIBoardCyton).to.equal("cyton");
+    });
+    it('should get right name for chan ganglion', function () {
+      expect(k.OBCIBoardGanglion).to.equal("ganglion");
+    });
+    it('should get right name for chan none', function () {
+      expect(k.OBCIBoardNone).to.equal("none");
+    });
+  });
+  describe('numberOfChannelsForBoardTypes', function () {
+    it('should get right num chan for daisy board', function () {
+      expect(k.numberOfChannelsForBoardType(k.OBCIBoardDaisy)).to.equal(16);
+    });
+    it('should get right num chan for cyton board', function () {
+      expect(k.numberOfChannelsForBoardType(k.OBCIBoardCyton)).to.equal(8);
+    });
+    it('should get right num chan for ganglion', function () {
+      expect(k.numberOfChannelsForBoardType(k.OBCIBoardGanglion)).to.equal(4);
+    });
+    it('should get right num chan for none', function () {
+      expect(k.numberOfChannelsForBoardType(k.OBCIBoardNone)).to.equal(0);
+    });
+  });
   describe('#getChannelSetter', function () {
     // 'channel 1, power on, gain 24, inputType normal, bias include, srb2 connect, srb1 dissconnect'
     describe('channel input selection works', function () {

--- a/test/openBCIUtilities-test.js
+++ b/test/openBCIUtilities-test.js
@@ -917,6 +917,7 @@ describe('openBCIUtilities', function () {
   });
   describe('#makeDaisySampleObject', function () {
     let lowerSampleObject, upperSampleObject, daisySampleObject;
+    let lowerSampleObjectNoScale, upperSampleObjectNoScale, daisySampleObjectNoScale;
     before(() => {
       // Make the lower sample (channels 1-8)
       lowerSampleObject = openBCIUtilities.newSample(1);
@@ -930,37 +931,135 @@ describe('openBCIUtilities', function () {
       upperSampleObject.auxData = [3, 4, 5];
       upperSampleObject.timestamp = 8;
 
-      // Call the function under test
       daisySampleObject = openBCIUtilities.makeDaisySampleObject(lowerSampleObject, upperSampleObject);
+
+      // lowerSampleObjectNoScale = openBCIUtilities.newSample(1);
+      // lowerSampleObjectNoScale.channelDataCounts = [1, 2, 3, 4, 5, 6, 7, 8];
+      // lowerSampleObjectNoScale.auxData = [0, 1, 2];
+      // lowerSampleObjectNoScale.timestamp = 4;
+      // lowerSampleObjectNoScale.accelData = [0.5, -0.5, 1];
+      // // Make the upper sample (channels 9-16)
+      // upperSampleObjectNoScale = openBCIUtilities.newSample(2);
+      // upperSampleObjectNoScale.channelDataCounts = [9, 10, 11, 12, 13, 14, 15, 16];
+      // upperSampleObjectNoScale.auxData = [3, 4, 5];
+      // upperSampleObjectNoScale.timestamp = 8;
+      //
+      // // Call the function under test
+      // daisySampleObjectNoScale = openBCIUtilities.makeDaisySampleObject(lowerSampleObjectNoScale, upperSampleObjectNoScale);
     });
     it('should make a channelData array 16 elements long', function () {
       expect(daisySampleObject.channelData).to.have.length(k.OBCINumberOfChannelsDaisy);
+      // expect(daisySampleObjectNoScale.channelDataCounts).to.have.length(k.OBCINumberOfChannelsDaisy);
     });
     it('should make a channelData array with lower array in front of upper array', function () {
       for (let i = 0; i < 16; i++) {
         expect(daisySampleObject.channelData[i]).to.equal(i + 1);
+        // expect(daisySampleObjectNoScale.channelDataCounts[i]).to.equal(i + 1);
       }
     });
     it('should make the sample number equal to the second packet divided by two', function () {
       expect(daisySampleObject.sampleNumber).to.equal(upperSampleObject.sampleNumber / 2);
+      // expect(daisySampleObjectNoScale.sampleNumber).to.equal(upperSampleObject.sampleNumber / 2);
     });
     it('should put the aux packets in an object', function () {
       expect(daisySampleObject.auxData).to.have.property('lower');
       expect(daisySampleObject.auxData).to.have.property('upper');
+      // expect(daisySampleObjectNoScale.auxData).to.have.property('lower');
+      // expect(daisySampleObjectNoScale.auxData).to.have.property('upper');
     });
     it('should put the aux packets in an object in the right order', function () {
       for (let i = 0; i < 3; i++) {
         expect(daisySampleObject.auxData['lower'][i]).to.equal(i);
         expect(daisySampleObject.auxData['upper'][i]).to.equal(i + 3);
+        // expect(daisySampleObjectNoScale.auxData['lower'][i]).to.equal(i);
+        // expect(daisySampleObjectNoScale.auxData['upper'][i]).to.equal(i + 3);
       }
     });
     it('should average the two timestamps together', function () {
       let expectedAverage = (upperSampleObject.timestamp + lowerSampleObject.timestamp) / 2;
       expect(daisySampleObject.timestamp).to.equal(expectedAverage);
+      // expect(daisySampleObjectNoScale.timestamp).to.equal(expectedAverage);
     });
     it('should place the old timestamps in an object', function () {
       expect(daisySampleObject._timestamps.lower).to.equal(lowerSampleObject.timestamp);
       expect(daisySampleObject._timestamps.upper).to.equal(upperSampleObject.timestamp);
+      // expect(upperSampleObjectNoScale._timestamps.lower).to.equal(upperSampleObjectNoScale.timestamp);
+      // expect(upperSampleObjectNoScale._timestamps.upper).to.equal(upperSampleObjectNoScale.timestamp);
+    });
+    it('should store an accelerometer value if present', function () {
+      expect(daisySampleObject).to.have.property('accelData');
+    });
+  });
+
+  describe('#makeDaisySampleObjectWifi', function () {
+    let lowerSampleObject, upperSampleObject, daisySampleObject;
+    let lowerSampleObjectNoScale, upperSampleObjectNoScale, daisySampleObjectNoScale;
+    before(() => {
+      // Make the lower sample (channels 1-8)
+      lowerSampleObject = openBCIUtilities.newSample(1);
+      lowerSampleObject.channelData = [1, 2, 3, 4, 5, 6, 7, 8];
+      lowerSampleObject.auxData = [0, 1, 2];
+      lowerSampleObject.timestamp = 4;
+      lowerSampleObject.accelData = [0.5, -0.5, 1];
+      // Make the upper sample (channels 9-16)
+      upperSampleObject = openBCIUtilities.newSample(2);
+      upperSampleObject.channelData = [9, 10, 11, 12, 13, 14, 15, 16];
+      upperSampleObject.auxData = [3, 4, 5];
+      upperSampleObject.timestamp = 8;
+
+      daisySampleObject = openBCIUtilities.makeDaisySampleObjectWifi(lowerSampleObject, upperSampleObject);
+
+      lowerSampleObjectNoScale = openBCIUtilities.newSample(1);
+      lowerSampleObjectNoScale.channelDataCounts = [1, 2, 3, 4, 5, 6, 7, 8];
+      lowerSampleObjectNoScale.auxData = [0, 1, 2];
+      lowerSampleObjectNoScale.timestamp = 4;
+      lowerSampleObjectNoScale.accelData = [0.5, -0.5, 1];
+      // Make the upper sample (channels 9-16)
+      upperSampleObjectNoScale = openBCIUtilities.newSample(2);
+      upperSampleObjectNoScale.channelDataCounts = [9, 10, 11, 12, 13, 14, 15, 16];
+      upperSampleObjectNoScale.auxData = [3, 4, 5];
+      upperSampleObjectNoScale.timestamp = 8;
+
+      // Call the function under test
+      daisySampleObjectNoScale = openBCIUtilities.makeDaisySampleObjectWifi(lowerSampleObjectNoScale, upperSampleObjectNoScale);
+    });
+    it('should make a channelData array 16 elements long', function () {
+      expect(daisySampleObject.channelData).to.have.length(k.OBCINumberOfChannelsDaisy);
+      expect(daisySampleObjectNoScale.channelDataCounts).to.have.length(k.OBCINumberOfChannelsDaisy);
+    });
+    it('should make a channelData array with lower array in front of upper array', function () {
+      for (let i = 0; i < 16; i++) {
+        expect(daisySampleObject.channelData[i]).to.equal(i + 1);
+        expect(daisySampleObjectNoScale.channelDataCounts[i]).to.equal(i + 1);
+      }
+    });
+    it('should make the sample number equal to the second packet divided by two', function () {
+      expect(daisySampleObject.sampleNumber).to.equal(upperSampleObject.sampleNumber);
+      expect(daisySampleObjectNoScale.sampleNumber).to.equal(upperSampleObject.sampleNumber);
+    });
+    it('should put the aux packets in an object', function () {
+      expect(daisySampleObject.auxData).to.have.property('lower');
+      expect(daisySampleObject.auxData).to.have.property('upper');
+      expect(daisySampleObjectNoScale.auxData).to.have.property('lower');
+      expect(daisySampleObjectNoScale.auxData).to.have.property('upper');
+    });
+    it('should put the aux packets in an object in the right order', function () {
+      for (let i = 0; i < 3; i++) {
+        expect(daisySampleObject.auxData['lower'][i]).to.equal(i);
+        expect(daisySampleObject.auxData['upper'][i]).to.equal(i + 3);
+        expect(daisySampleObjectNoScale.auxData['lower'][i]).to.equal(i);
+        expect(daisySampleObjectNoScale.auxData['upper'][i]).to.equal(i + 3);
+      }
+    });
+    it('should take the lower timestamp', function () {
+      expect(daisySampleObject.timestamp).to.equal(lowerSampleObject.timestamp);
+      expect(daisySampleObjectNoScale.timestamp).to.equal(lowerSampleObject.timestamp);
+    });
+    it('should place the old timestamps in an object', function () {
+      expect(daisySampleObject._timestamps.lower).to.equal(lowerSampleObject.timestamp);
+      expect(daisySampleObject._timestamps.upper).to.equal(upperSampleObject.timestamp);
+      expect(daisySampleObjectNoScale._timestamps.lower).to.equal(lowerSampleObjectNoScale.timestamp);
+      expect(daisySampleObjectNoScale._timestamps.upper).to.equal(upperSampleObjectNoScale.timestamp);
     });
     it('should store an accelerometer value if present', function () {
       expect(daisySampleObject).to.have.property('accelData');

--- a/test/openBCIUtilities-test.js
+++ b/test/openBCIUtilities-test.js
@@ -41,14 +41,14 @@ describe('openBCIUtilities', function () {
   describe('#parsePacketStandardAccel', function () {
     it('should return the packet', function () {
       expect(openBCIUtilities.parsePacketStandardAccel({
-        gains: defaultChannelSettingsArray,
+        channelSettings: defaultChannelSettingsArray,
         rawDataPacket: sampleBuf,
         scale: true
       })).to.not.equal(null);
     });
     it('should have the correct sample number', function () {
       let sample = openBCIUtilities.parsePacketStandardAccel({
-        gains: defaultChannelSettingsArray,
+        channelSettings: defaultChannelSettingsArray,
         rawDataPacket: sampleBuf,
         scale: true
       });
@@ -58,7 +58,7 @@ describe('openBCIUtilities', function () {
     it('all the channels should have the same number value as their (index + 1) * scaleFactor', function () {
       // sampleBuf has its channel number for each 3 byte integer. See line 20...
       let sample = openBCIUtilities.parsePacketStandardAccel({
-        gains: defaultChannelSettingsArray,
+        channelSettings: defaultChannelSettingsArray,
         rawDataPacket: sampleBuf,
         scale: true
       });
@@ -74,7 +74,7 @@ describe('openBCIUtilities', function () {
     it('all the channels should have the same number value as their (index + 1)', function () {
       // sampleBuf has its channel number for each 3 byte integer. See line 20...
       let sample = openBCIUtilities.parsePacketStandardAccel({
-        gains: defaultChannelSettingsArray,
+        channelSettings: defaultChannelSettingsArray,
         rawDataPacket: sampleBuf,
         scale: false
       });
@@ -88,7 +88,7 @@ describe('openBCIUtilities', function () {
     });
     it('all the auxs should have the same number value as their index * scaleFactor', function () {
       let sample = openBCIUtilities.parsePacketStandardAccel({
-        gains: defaultChannelSettingsArray,
+        channelSettings: defaultChannelSettingsArray,
         rawDataPacket: sampleBuf,
         scale: true
       });
@@ -103,7 +103,7 @@ describe('openBCIUtilities', function () {
       let taco = new Buffer([0x81]);
       taco.copy(temp, 2);
       let sample = openBCIUtilities.parsePacketStandardAccel({
-        gains: defaultChannelSettingsArray,
+        channelSettings: defaultChannelSettingsArray,
         rawDataPacket: temp,
         scale: true
       });
@@ -114,7 +114,7 @@ describe('openBCIUtilities', function () {
       let taco = new Buffer([0x81]);
       taco.copy(temp, 26);
       let sample = openBCIUtilities.parsePacketStandardAccel({
-        gains: defaultChannelSettingsArray,
+        channelSettings: defaultChannelSettingsArray,
         rawDataPacket: temp,
         scale: true
       });
@@ -130,7 +130,7 @@ describe('openBCIUtilities', function () {
         let taco = new Buffer([i]);
         taco.copy(temp, 2);
         let sample = openBCIUtilities.parsePacketStandardAccel({
-          gains: defaultChannelSettingsArray,
+          channelSettings: defaultChannelSettingsArray,
           rawDataPacket: temp,
           scale: true
         });
@@ -141,7 +141,7 @@ describe('openBCIUtilities', function () {
     it('has the right sample number', function () {
       let expectedSampleNumber = 0x45;
       let sample = openBCIUtilities.parsePacketStandardAccel({
-        gains: defaultChannelSettingsArray,
+        channelSettings: defaultChannelSettingsArray,
         rawDataPacket: sampleBuf,
         scale: true
       });
@@ -149,7 +149,7 @@ describe('openBCIUtilities', function () {
     });
     it('has the right stop byte', function () {
       let sample = openBCIUtilities.parsePacketStandardAccel({
-        gains: defaultChannelSettingsArray,
+        channelSettings: defaultChannelSettingsArray,
         rawDataPacket: sampleBuf,
         scale: true
       });
@@ -157,7 +157,7 @@ describe('openBCIUtilities', function () {
     });
     it('has the right start byte', function () {
       let sample = openBCIUtilities.parsePacketStandardAccel({
-        gains: defaultChannelSettingsArray,
+        channelSettings: defaultChannelSettingsArray,
         rawDataPacket: sampleBuf,
         scale: true
       });
@@ -195,7 +195,7 @@ describe('openBCIUtilities', function () {
 
       let sample = openBCIUtilities.parsePacketStandardRawAux({
         rawDataPacket: packet,
-        gains: defaultChannelSettingsArray,
+        channelSettings: defaultChannelSettingsArray,
         scale: true
       });
       expect(Buffer.isBuffer(sample.auxData)).to.be.true();
@@ -207,7 +207,7 @@ describe('openBCIUtilities', function () {
 
       let sample = openBCIUtilities.parsePacketStandardRawAux({
         rawDataPacket: packet,
-        gains: defaultChannelSettingsArray,
+        channelSettings: defaultChannelSettingsArray,
         scale: true
       });
       for (let i = 0; i < 6; i++) {
@@ -218,7 +218,7 @@ describe('openBCIUtilities', function () {
       packet = openBCIUtilities.samplePacketStandardRawAux(0);
       let sample = openBCIUtilities.parsePacketStandardRawAux({
         rawDataPacket: packet,
-        gains: defaultChannelSettingsArray,
+        channelSettings: defaultChannelSettingsArray,
         scale: true
       });
       sample.channelData.forEach((channelValue, index) => {
@@ -229,7 +229,7 @@ describe('openBCIUtilities', function () {
       packet = openBCIUtilities.samplePacketStandardRawAux(0);
       let sample = openBCIUtilities.parsePacketStandardRawAux({
         rawDataPacket: packet,
-        gains: defaultChannelSettingsArray,
+        channelSettings: defaultChannelSettingsArray,
         scale: false
       });
       sample.channelDataCounts.forEach((channelValue, index) => {
@@ -241,7 +241,7 @@ describe('openBCIUtilities', function () {
       packet = openBCIUtilities.samplePacketStandardRawAux(expectedSampleNumber);
       let sample = openBCIUtilities.parsePacketStandardRawAux({
         rawDataPacket: packet,
-        gains: defaultChannelSettingsArray,
+        channelSettings: defaultChannelSettingsArray,
         scale: true
       });
       expect(sample.sampleNumber).to.equal(expectedSampleNumber);
@@ -250,7 +250,7 @@ describe('openBCIUtilities', function () {
       packet = openBCIUtilities.samplePacketStandardRawAux(0);
       let sample = openBCIUtilities.parsePacketStandardRawAux({
         rawDataPacket: packet,
-        gains: defaultChannelSettingsArray,
+        channelSettings: defaultChannelSettingsArray,
         scale: true
       });
       expect(sample.stopByte).to.equal(openBCIUtilities.makeTailByteFromPacketType(k.OBCIStreamPacketStandardRawAux));
@@ -259,7 +259,7 @@ describe('openBCIUtilities', function () {
       packet = openBCIUtilities.samplePacketStandardRawAux(0);
       let sample = openBCIUtilities.parsePacketStandardRawAux({
         rawDataPacket: packet,
-        gains: defaultChannelSettingsArray,
+        channelSettings: defaultChannelSettingsArray,
         scale: true
       });
       expect(sample.startByte).to.equal(0xA0);
@@ -344,7 +344,7 @@ describe('openBCIUtilities', function () {
 
       let sample = openBCIUtilities.parsePacketTimeSyncedAccel({
         rawDataPacket: packet1,
-        gains: defaultChannelSettingsArray,
+        channelSettings: defaultChannelSettingsArray,
         timeOffset: 0,
         accelArray
       });
@@ -352,7 +352,7 @@ describe('openBCIUtilities', function () {
 
       sample = openBCIUtilities.parsePacketTimeSyncedAccel({
         rawDataPacket: packet2,
-        gains: defaultChannelSettingsArray,
+        channelSettings: defaultChannelSettingsArray,
         timeOffset: 0,
         accelArray
       });
@@ -360,7 +360,7 @@ describe('openBCIUtilities', function () {
 
       sample = openBCIUtilities.parsePacketTimeSyncedAccel({
         rawDataPacket: packet3,
-        gains: defaultChannelSettingsArray,
+        channelSettings: defaultChannelSettingsArray,
         timeOffset: 0,
         accelArray
       });
@@ -377,19 +377,19 @@ describe('openBCIUtilities', function () {
 
       let sample = openBCIUtilities.parsePacketTimeSyncedAccel({
         rawDataPacket: packet1,
-        gains: defaultChannelSettingsArray,
+        channelSettings: defaultChannelSettingsArray,
         timeOffset: 0,
         accelArray
       });
       sample = openBCIUtilities.parsePacketTimeSyncedAccel({
         rawDataPacket: packet2,
-        gains: defaultChannelSettingsArray,
+        channelSettings: defaultChannelSettingsArray,
         timeOffset: 0,
         accelArray
       });
       sample = openBCIUtilities.parsePacketTimeSyncedAccel({
         rawDataPacket: packet3,
-        gains: defaultChannelSettingsArray,
+        channelSettings: defaultChannelSettingsArray,
         timeOffset: 0,
         accelArray
       });
@@ -401,7 +401,7 @@ describe('openBCIUtilities', function () {
       packet1 = openBCIUtilities.samplePacketAccelTimeSynced(0);
       let sample = openBCIUtilities.parsePacketTimeSyncedAccel({
         rawDataPacket: packet1,
-        gains: defaultChannelSettingsArray,
+        channelSettings: defaultChannelSettingsArray,
         timeOffset: 0,
         scale: true,
         accelArray
@@ -414,7 +414,7 @@ describe('openBCIUtilities', function () {
       packet1 = openBCIUtilities.samplePacketAccelTimeSynced(0);
       let sample = openBCIUtilities.parsePacketTimeSyncedAccel({
         rawDataPacket: packet1,
-        gains: defaultChannelSettingsArray,
+        channelSettings: defaultChannelSettingsArray,
         timeOffset: 0,
         scale: false,
         accelArray
@@ -428,7 +428,7 @@ describe('openBCIUtilities', function () {
       packet1 = openBCIUtilities.samplePacketAccelTimeSynced(expectedSampleNumber);
       let sample = openBCIUtilities.parsePacketTimeSyncedAccel({
         rawDataPacket: packet1,
-        gains: defaultChannelSettingsArray,
+        channelSettings: defaultChannelSettingsArray,
         timeOffset: 0,
         accelArray
       }); // sampleBuf has its channel number for each 3 byte integer. See line 20...
@@ -438,7 +438,7 @@ describe('openBCIUtilities', function () {
       packet1 = openBCIUtilities.samplePacketAccelTimeSynced(0);
       let sample = openBCIUtilities.parsePacketTimeSyncedAccel({
         rawDataPacket: packet1,
-        gains: defaultChannelSettingsArray,
+        channelSettings: defaultChannelSettingsArray,
         timeOffset: 0,
         accelArray
       }); // sampleBuf has its channel number for each 3 byte integer. See line 20...
@@ -448,7 +448,7 @@ describe('openBCIUtilities', function () {
       packet1 = openBCIUtilities.samplePacketAccelTimeSynced(0);
       let sample = openBCIUtilities.parsePacketTimeSyncedAccel({
         rawDataPacket: packet1,
-        gains: defaultChannelSettingsArray,
+        channelSettings: defaultChannelSettingsArray,
         timeOffset: 0,
         accelArray
       }); // sampleBuf has its channel number for each 3 byte integer. See line 20...
@@ -458,7 +458,7 @@ describe('openBCIUtilities', function () {
       it('wrong number of bytes', function () {
         expect(openBCIUtilities.parsePacketTimeSyncedAccel.bind(openBCIUtilities, {
           rawDataPacket: new Buffer(5),
-          gains: defaultChannelSettingsArray,
+          channelSettings: defaultChannelSettingsArray,
           timeOffset: 0,
           accelArray
         })).to.throw(k.OBCIErrorInvalidByteLength);
@@ -488,7 +488,7 @@ describe('openBCIUtilities', function () {
 
       let sample = openBCIUtilities.parsePacketTimeSyncedRawAux({
         rawDataPacket: packet,
-        gains: defaultChannelSettingsArray,
+        channelSettings: defaultChannelSettingsArray,
         timeOffset: 0
       });
       expect(sample).to.have.property('auxData');
@@ -501,7 +501,7 @@ describe('openBCIUtilities', function () {
       let sample = openBCIUtilities.parsePacketTimeSyncedRawAux({
         rawDataPacket: packet,
         timeOffset: 0,
-        gains: defaultChannelSettingsArray,
+        channelSettings: defaultChannelSettingsArray,
         scale: true
       });
       sample.channelData.forEach((channelValue, index) => {
@@ -523,7 +523,7 @@ describe('openBCIUtilities', function () {
       let expectedSampleNumber = 69;
       packet = openBCIUtilities.samplePacketRawAuxTimeSynced(expectedSampleNumber);
       let sample = openBCIUtilities.parsePacketTimeSyncedRawAux({
-        gains: defaultChannelSettingsArray,
+        channelSettings: defaultChannelSettingsArray,
         rawDataPacket: packet,
         timeOffset: 0
       });
@@ -532,7 +532,7 @@ describe('openBCIUtilities', function () {
     it('has the right stop byte', function () {
       packet = openBCIUtilities.samplePacketRawAuxTimeSynced(0);
       let sample = openBCIUtilities.parsePacketTimeSyncedRawAux({
-        gains: defaultChannelSettingsArray,
+        channelSettings: defaultChannelSettingsArray,
         rawDataPacket: packet,
         timeOffset: 0
       });
@@ -541,7 +541,7 @@ describe('openBCIUtilities', function () {
     it('has the right start byte', function () {
       packet = openBCIUtilities.samplePacketRawAuxTimeSynced(0);
       let sample = openBCIUtilities.parsePacketTimeSyncedRawAux({
-        gains: defaultChannelSettingsArray,
+        channelSettings: defaultChannelSettingsArray,
         rawDataPacket: packet,
         timeOffset: 0
       });
@@ -550,7 +550,7 @@ describe('openBCIUtilities', function () {
     describe('#errorConditions', function () {
       it('wrong number of bytes', function () {
         expect(openBCIUtilities.parsePacketTimeSyncedRawAux.bind(openBCIUtilities, {
-          gains: defaultChannelSettingsArray,
+          channelSettings: defaultChannelSettingsArray,
           rawDataPacket: new Buffer(5),
           timeOffset: 0
         })).to.throw(k.OBCIErrorInvalidByteLength);
@@ -578,7 +578,7 @@ describe('openBCIUtilities', function () {
     it('should convert channel data to binary', function () {
       let sample = openBCIUtilities.parsePacketStandardAccel({
         rawDataPacket: packetBuffer,
-        gains: defaultChannelSettingsArray
+        channelSettings: defaultChannelSettingsArray
       });
       for (let i = 0; i < k.OBCINumberOfChannelsDefault; i++) {
         expect(sample.channelData[i]).to.be.approximately(newSample.channelData[i], 0.001);
@@ -587,7 +587,7 @@ describe('openBCIUtilities', function () {
     it('should convert aux data to binary', function () {
       let sample = openBCIUtilities.parsePacketStandardAccel({
         rawDataPacket: packetBuffer,
-        gains: defaultChannelSettingsArray
+        channelSettings: defaultChannelSettingsArray
       });
       for (let i = 0; i < 3; i++) {
         expect(sample.accelData[i]).to.be.approximately(newSample.auxData[i], 0.001);
@@ -618,7 +618,7 @@ describe('openBCIUtilities', function () {
     it('should convert channel data to binary', function () {
       let sample = openBCIUtilities.parsePacketStandardRawAux({
         rawDataPacket: packetBuffer,
-        gains: defaultChannelSettingsArray
+        channelSettings: defaultChannelSettingsArray
       });
       for (let i = 0; i < k.OBCINumberOfChannelsDefault; i++) {
         expect(sample.channelData[i]).to.be.approximately(newSample.channelData[i], 0.001);
@@ -627,7 +627,7 @@ describe('openBCIUtilities', function () {
     it('should get raw aux buffer', function () {
       let sample = openBCIUtilities.parsePacketStandardRawAux({
         rawDataPacket: packetBuffer,
-        gains: defaultChannelSettingsArray
+        channelSettings: defaultChannelSettingsArray
       });
       expect(sample.auxData).to.exist();
       expect(bufferEqual(rawBuffer, sample.auxData)).to.be.true();
@@ -663,7 +663,7 @@ describe('openBCIUtilities', function () {
     it('should convert channel data to binary', function () {
       let sample = openBCIUtilities.parsePacketTimeSyncedAccel({
         rawDataPacket: packetBuffer,
-        gains: channelSettingsArray,
+        channelSettings: channelSettingsArray,
         timeOffset: 0,
         accelArray
       });
@@ -674,7 +674,7 @@ describe('openBCIUtilities', function () {
     it('should get board time', function () {
       let sample = openBCIUtilities.parsePacketTimeSyncedAccel({
         rawDataPacket: packetBuffer,
-        gains: channelSettingsArray,
+        channelSettings: channelSettingsArray,
         timeOffset: 0,
         accelArray
       });
@@ -685,7 +685,7 @@ describe('openBCIUtilities', function () {
       let timeOffset = 80;
       let sample = openBCIUtilities.parsePacketTimeSyncedAccel({
         rawDataPacket: packetBuffer,
-        gains: channelSettingsArray,
+        channelSettings: channelSettingsArray,
         timeOffset: timeOffset,
         accelArray
       });
@@ -724,7 +724,7 @@ describe('openBCIUtilities', function () {
       let sample = openBCIUtilities.parsePacketTimeSyncedRawAux({
         rawDataPacket: packetBuffer,
         timeOffset: 0,
-        gains: channelSettingsArray
+        channelSettings: channelSettingsArray
       });
       for (let i = 0; i < k.OBCINumberOfChannelsDefault; i++) {
         expect(sample.channelData[i]).to.be.approximately(newSample.channelData[i], 0.001);
@@ -1086,69 +1086,48 @@ describe('openBCIUtilities', function () {
     beforeEach(() => {
       sampleBuf = openBCIUtilities.samplePacket(0);
     });
-    it('should multiply each channel by the proper scale value', function () {
-      let chanArr = k.channelSettingsArrayInit(k.OBCINumberOfChannelsDefault); // Not in daisy mode
-      let scaleFactor = 4.5 / 24 / (Math.pow(2, 23) - 1);
-      // Call the function under test
-      let valueArray = openBCIUtilities.getChannelDataArray(sampleBuf, chanArr);
-      for (let j = 0; j < k.OBCINumberOfChannelsDefault; j++) {
-        console.log(`channel data ${j + 1}: ${valueArray[j]} : actual ${scaleFactor * (j + 1)}`);
-        expect(valueArray[j]).to.be.closeTo(scaleFactor * (j + 1), 0.0001);
-      }
-    });
-    it('in daisy mode, on odd samples should use gains from index 0-7 of channel settings array', function () {
-      // Overwrite the default
-      sampleBuf = openBCIUtilities.samplePacket(1); // even's are the daisy channels
-      // Make a 16 element long channel settings array
-      let chanArr = k.channelSettingsArrayInit(k.OBCINumberOfChannelsDaisy);
-      // Set the upper (8-15) of channel settings array. If the function under test uses the 1 gain, then the test
-      //  will fail.
-      for (let i = k.OBCINumberOfChannelsDefault; i < k.OBCINumberOfChannelsDaisy; i++) {
-        chanArr[i].gain = 1;
-      }
-      let scaleFactor = 4.5 / 24 / (Math.pow(2, 23) - 1);
-      // Call the function under test
-      let valueArray = openBCIUtilities.getChannelDataArray(sampleBuf, chanArr);
-      for (let j = 0; j < k.OBCINumberOfChannelsDefault; j++) {
-        // console.log(`channel data ${j + 1}: ${valueArray[j]} : actual ${scaleFactor * (j + 1)}`)
-        expect(valueArray[j]).to.be.closeTo(scaleFactor * (j + 1), 0.0001);
-      }
-    });
-    it('in daisy mode, on even samples should use gains from index 8-15 of channel settings array', function () {
-      // Overwrite the default
-      sampleBuf = openBCIUtilities.samplePacket(2); // even's are the daisy channels
-      // Make a 16 element long channel settings array
-      let chanArr = k.channelSettingsArrayInit(k.OBCINumberOfChannelsDaisy);
-      // Set the lower (0-7) of channel settings array. If the function under test uses the 1 gain, then the test
-      //  will fail.
-      for (let i = 0; i < k.OBCINumberOfChannelsDefault; i++) {
-        chanArr[i].gain = 1;
-      }
-      // gain here is 24, the same as in the channel settings array
-      let scaleFactor = 4.5 / 24 / (Math.pow(2, 23) - 1);
-      // Call the function under test
-      let valueArray = openBCIUtilities.getChannelDataArray(sampleBuf, chanArr);
-      for (let j = 0; j < k.OBCINumberOfChannelsDefault; j++) {
-        // console.log(`channel data ${j + 1}: ${valueArray[j]} : actual ${scaleFactor * (j + 1)}`)
-        expect(valueArray[j]).to.be.closeTo(scaleFactor * (j + 1), 0.0001);
-      }
+    it('should reject when channelSettingsArray is not in fact an array', function () {
+      expect(openBCIUtilities.getChannelDataArray.bind(openBCIUtilities, {
+        rawDataPacket: sampleBuf,
+        channelSettings: {},
+        protocol: k.OBCIProtocolSerial
+      })).to.throw('Error [getChannelDataArray]: Channel Settings must be an array!');
     });
     it('in default mode, should reject when empty channel setting array', function () {
       badChanArray = new Array(k.OBCINumberOfChannelsDefault).fill(0);
-      expect(openBCIUtilities.getChannelDataArray.bind(openBCIUtilities, sampleBuf, badChanArray)).to.throw('Error [getChannelDataArray]: Invalid channel settings object at index 0');
+      expect(openBCIUtilities.getChannelDataArray.bind(openBCIUtilities, {
+        rawDataPacket: sampleBuf,
+        channelSettings: badChanArray,
+        protocol: k.OBCIProtocolWifi
+      })).to.throw('Error [getChannelDataArray]: Invalid channel settings object at index 0');
+    });
+    it('should reject when unsupported protocol', function () {
+      expect(openBCIUtilities.getChannelDataArray.bind(openBCIUtilities, {
+        rawDataPacket: sampleBuf,
+        channelSettings: k.channelSettingsArrayInit(k.OBCINumberOfChannelsDefault),
+        protocol: 'taco'
+      })).to.throw('Error [getChannelDataArray]: Invalid protocol must be wifi or serial');
     });
     it('in daisy mode, should reject when empty channel setting array', function () {
       badChanArray = new Array(k.OBCINumberOfChannelsDaisy).fill(0);
-      expect(openBCIUtilities.getChannelDataArray.bind(openBCIUtilities, sampleBuf, badChanArray)).to.throw('Error [getChannelDataArray]: Invalid channel settings object at index 0');
+      expect(openBCIUtilities.getChannelDataArray.bind(openBCIUtilities, {
+        rawDataPacket: sampleBuf,
+        channelSettings: badChanArray,
+        protocol: k.OBCIProtocolWifi
+      })).to.throw('Error [getChannelDataArray]: Invalid channel settings object at index 0');
     });
-    it('in default mode, should reject if not numbers in gain position', function () {
+    it('in cyton mode, should reject if not numbers in gain position', function () {
       badChanArray = [];
       for (let i = 0; i < k.OBCINumberOfChannelsDefault; i++) {
         badChanArray.push({
           gain: 'taco'
         });
       }
-      expect(openBCIUtilities.getChannelDataArray.bind(openBCIUtilities, sampleBuf, badChanArray)).to.throw('Error [getChannelDataArray]: Property gain of channelSettingsObject not or type Number');
+      expect(openBCIUtilities.getChannelDataArray.bind(openBCIUtilities, {
+        rawDataPacket: sampleBuf,
+        channelSettings: badChanArray,
+        protocol: k.OBCIProtocolWifi
+      })).to.throw('Error [getChannelDataArray]: Property gain of channelSettingsObject not or type Number');
     });
     it('in daisy mode, should reject if not numbers in gain position', function () {
       badChanArray = [];
@@ -1157,10 +1136,153 @@ describe('openBCIUtilities', function () {
           gain: 'taco'
         });
       }
-      expect(openBCIUtilities.getChannelDataArray.bind(openBCIUtilities, sampleBuf, badChanArray)).to.throw('Error [getChannelDataArray]: Property gain of channelSettingsObject not or type Number');
+      expect(openBCIUtilities.getChannelDataArray.bind(openBCIUtilities, {
+        rawDataPacket: sampleBuf,
+        channelSettings: badChanArray,
+        protocol: k.OBCIProtocolWifi
+      })).to.throw('Error [getChannelDataArray]: Property gain of channelSettingsObject not or type Number');
     });
-    it('should reject when channelSettingsArray is not in fact an array', function () {
-      expect(openBCIUtilities.getChannelDataArray.bind(openBCIUtilities, sampleBuf, {})).to.throw('Error [getChannelDataArray]: Channel Settings must be an array!');
+    describe('Serial', function () {
+      it('should multiply each channel by the proper scale value', function () {
+        let chanArr = k.channelSettingsArrayInit(k.OBCINumberOfChannelsDefault); // Not in daisy mode
+        let scaleFactor = 4.5 / 24 / (Math.pow(2, 23) - 1);
+        // Call the function under test
+        let valueArray = openBCIUtilities.getChannelDataArray({
+          rawDataPacket: sampleBuf,
+          channelSettings: chanArr,
+          protocol: k.OBCIProtocolSerial
+        });
+        for (let j = 0; j < k.OBCINumberOfChannelsDefault; j++) {
+          // console.log(`channel data ${j + 1}: ${valueArray[j]} : actual ${scaleFactor * (j + 1)}`);
+          expect(valueArray[j]).to.be.closeTo(scaleFactor * (j + 1), 0.0001);
+        }
+      });
+      it('in daisy mode, on odd samples should use gains from index 0-7 of channel settings array', function () {
+        // Overwrite the default
+        sampleBuf = openBCIUtilities.samplePacket(1); // even's are the daisy channels
+        // Make a 16 element long channel settings array
+        let chanArr = k.channelSettingsArrayInit(k.OBCINumberOfChannelsDaisy);
+        // Set the upper (8-15) of channel settings array. If the function under test uses the 1 gain, then the test
+        //  will fail.
+        for (let i = k.OBCINumberOfChannelsDefault; i < k.OBCINumberOfChannelsDaisy; i++) {
+          chanArr[i].gain = 1;
+        }
+        let scaleFactor = 4.5 / 24 / (Math.pow(2, 23) - 1);
+        // Call the function under test
+        let valueArray = openBCIUtilities.getChannelDataArray({
+          rawDataPacket: sampleBuf,
+          channelSettings: chanArr,
+          protocol: k.OBCIProtocolSerial
+        });
+        for (let j = 0; j < k.OBCINumberOfChannelsDefault; j++) {
+          // console.log(`channel data ${j + 1}: ${valueArray[j]} : actual ${scaleFactor * (j + 1)}`)
+          expect(valueArray[j]).to.be.closeTo(scaleFactor * (j + 1), 0.0001);
+        }
+      });
+      it('in daisy mode, on even samples should use gains from index 8-15 of channel settings array', function () {
+        // Overwrite the default
+        sampleBuf = openBCIUtilities.samplePacket(2); // even's are the daisy channels
+        // Make a 16 element long channel settings array
+        let chanArr = k.channelSettingsArrayInit(k.OBCINumberOfChannelsDaisy);
+        // Set the lower (0-7) of channel settings array. If the function under test uses the 1 gain, then the test
+        //  will fail.
+        for (let i = 0; i < k.OBCINumberOfChannelsDefault; i++) {
+          chanArr[i].gain = 1;
+        }
+        // gain here is 24, the same as in the channel settings array
+        let scaleFactor = 4.5 / 24 / (Math.pow(2, 23) - 1);
+        // Call the function under test
+        let valueArray = openBCIUtilities.getChannelDataArray({
+          rawDataPacket: sampleBuf,
+          channelSettings: chanArr,
+          protocol: k.OBCIProtocolSerial
+        });
+        for (let j = 0; j < k.OBCINumberOfChannelsDefault; j++) {
+          // console.log(`channel data ${j + 1}: ${valueArray[j]} : actual ${scaleFactor * (j + 1)}`)
+          expect(valueArray[j]).to.be.closeTo(scaleFactor * (j + 1), 0.0001);
+        }
+      });
+    });
+    describe('Wifi', function () {
+      it('should multiply each channel by the ganglion scale value when num chan is 4', function () {
+        let chanArr = k.channelSettingsArrayInit(k.OBCINumberOfChannelsGanglion); // Not in daisy mode
+        let scaleFactor = 1.2 / 51.0 / (Math.pow(2, 23) - 1);
+        // Call the function under test
+        let valueArray = openBCIUtilities.getChannelDataArray({
+          rawDataPacket: sampleBuf,
+          channelSettings: chanArr,
+          protocol: k.OBCIProtocolWifi
+        });
+        for (let j = 0; j < k.OBCINumberOfChannelsGanglion; j++) {
+          // console.log(`channel data ${j + 1}: ${valueArray[j]} : actual ${scaleFactor * (j + 1)}`);
+          expect(valueArray[j]).to.be.closeTo(scaleFactor * (j + 1), 0.0001);
+        }
+      });
+      it('should multiply each channel by the cyton scale value when num chan is 8', function () {
+        let chanArr = k.channelSettingsArrayInit(k.OBCINumberOfChannelsDefault); // Not in daisy mode
+        let scaleFactor = 4.5 / 24 / (Math.pow(2, 23) - 1);
+        // Call the function under test
+        let valueArray = openBCIUtilities.getChannelDataArray({
+          rawDataPacket: sampleBuf,
+          channelSettings: chanArr,
+          protocol: k.OBCIProtocolWifi
+        });
+        for (let j = 0; j < k.OBCINumberOfChannelsDefault; j++) {
+          // console.log(`channel data ${j + 1}: ${valueArray[j]} : actual ${scaleFactor * (j + 1)}`);
+          expect(valueArray[j]).to.be.closeTo(scaleFactor * (j + 1), 0.0001);
+        }
+      });
+      it('in daisy mode, when last sample num not equal to cur sample num should use gains from index 0-7 of channel settings array', function () {
+        // Overwrite the default
+        const lastSampleNumber = 0;
+        const curSampleNumber = lastSampleNumber + 1;
+        sampleBuf = openBCIUtilities.samplePacket(curSampleNumber);
+        // Make a 16 element long channel settings array
+        let chanArr = k.channelSettingsArrayInit(k.OBCINumberOfChannelsDaisy);
+        // Set the upper (8-15) of channel settings array. If the function under test uses the 1 gain, then the test
+        //  will fail.
+        for (let i = k.OBCINumberOfChannelsDefault; i < k.OBCINumberOfChannelsDaisy; i++) {
+          chanArr[i].gain = 1;
+        }
+        let scaleFactor = 4.5 / 24 / (Math.pow(2, 23) - 1);
+        // Call the function under test
+        let valueArray = openBCIUtilities.getChannelDataArray({
+          rawDataPacket: sampleBuf,
+          channelSettings: chanArr,
+          protocol: k.OBCIProtocolWifi,
+          lastSampleNumber
+        });
+        for (let j = 0; j < k.OBCINumberOfChannelsDefault; j++) {
+          // console.log(`channel data ${j + 1}: ${valueArray[j]} : actual ${scaleFactor * (j + 1)}`)
+          expect(valueArray[j]).to.be.closeTo(scaleFactor * (j + 1), 0.0001);
+        }
+      });
+      it('in daisy mode, when last sample number is equal to cur sample number should use gains from index 8-15 of channel settings array', function () {
+        // Overwrite the default
+        const lastSampleNumber = 1;
+        const curSampleNumber = lastSampleNumber;
+        sampleBuf = openBCIUtilities.samplePacket(curSampleNumber);
+        // Make a 16 element long channel settings array
+        let chanArr = k.channelSettingsArrayInit(k.OBCINumberOfChannelsDaisy);
+        // Set the lower (0-7) of channel settings array. If the function under test uses the 1 gain, then the test
+        //  will fail.
+        for (let i = 0; i < k.OBCINumberOfChannelsDefault; i++) {
+          chanArr[i].gain = 1;
+        }
+        // gain here is 24, the same as in the channel settings array
+        let scaleFactor = 4.5 / 24 / (Math.pow(2, 23) - 1);
+        // Call the function under test
+        let valueArray = openBCIUtilities.getChannelDataArray({
+          rawDataPacket: sampleBuf,
+          channelSettings: chanArr,
+          protocol: k.OBCIProtocolWifi,
+          lastSampleNumber
+        });
+        for (let j = 0; j < k.OBCINumberOfChannelsDefault; j++) {
+          // console.log(`channel data ${j + 1}: ${valueArray[j]} : actual ${scaleFactor * (j + 1)}`)
+          expect(valueArray[j]).to.be.closeTo(scaleFactor * (j + 1), 0.0001);
+        }
+      });
     });
   });
   describe('#countADSPresent', function () {
@@ -1913,7 +2035,7 @@ describe('#transformRawDataPacketsToSamples', function () {
     // Call the function under test
     const samples = openBCIUtilities.transformRawDataPacketsToSample({
       rawDataPackets: [buffer],
-      gains: defaultChannelSettingsArray
+      channelSettings: defaultChannelSettingsArray
     });
 
     // Ensure that we extracted only one buffer
@@ -1929,7 +2051,7 @@ describe('#transformRawDataPacketsToSamples', function () {
         openBCIUtilities.samplePacket(1),
         openBCIUtilities.samplePacket(2)
       ],
-      gains: defaultChannelSettingsArray
+      channelSettings: defaultChannelSettingsArray
     });
 
     // Ensure that we extracted only one buffer


### PR DESCRIPTION
# 0.0.6

### Bug Fixes

* Could not use 'daisy' with sample rate setter.

### New Features

* Add function in utilities for making daisy packets.
* Add code to `getChannelDataArray` for ganglion and daisy data being routed over wifi
* Create idea of protocols i.e. `BLE`, `Wifi`, and `Serial`

### Breaking changes

* `getChannelDataArray` now takes object as only arg.