### PR TITLE
Fix packet parsing issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,5 @@ node_js:
 install:
   - npm install --all
 script:
+  - npm run test-lint
   - npm run test-cov

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# 0.0.8
+
+### New Features
+
+* Sample object now has property `valid` of type `boolean`, `false` when error parseing packet, `true` otherwise. On `false` there will be another property called `error` of type `string` which contains an error message.
+
 # 0.0.7
 
 ### Continuous Integration

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,18 @@
+# 0.0.7
+
+### Continuous Integration
+
+* Add `npm run test-lint` to add linting to travis.yml
+
+### Bug Fixes
+
+* Last sample number was confusing to use with `transformRawDataPacketsToSample`
+
+### New Features
+
+* In openBCIUtilities.js add function `transformRawDataPacketToSample` to parse a single raw data packet
+* In openBCIConstants.js add function `rawDataToSampleObjectDefault(numChannels)` which should be used by drivers to create the object that is passed through each call to `transformRawDataPacketsToSample` 
+
 # 0.0.6
 
 ### Bug Fixes

--- a/openBCIConstants.js
+++ b/openBCIConstants.js
@@ -486,11 +486,11 @@ const obciNobleEmitterStateChange = 'stateChange';
 const obciNobleStatePoweredOn = 'poweredOn';
 
 /** Protocols */
-const obciProtocolBLE = "ble";
-const obciProtocolSerial = "serial";
-const obciProtocolWifi = "wifi";
+const obciProtocolBLE = 'ble';
+const obciProtocolSerial = 'serial';
+const obciProtocolWifi = 'wifi';
 
-module.exports = {
+const constantsModule = {
   /** Turning channels off */
   OBCIChannelOff1: obciChannelOff1,
   OBCIChannelOff2: obciChannelOff2,
@@ -1178,11 +1178,13 @@ module.exports = {
   commandSampleRateForCmdCyton,
   commandSampleRateForCmdGanglion,
   commandBoardModeForMode,
+  rawDataToSampleObjectDefault,
   /** Protocols */
   OBCIProtocolBLE: obciProtocolBLE,
   OBCIProtocolSerial: obciProtocolSerial,
   OBCIProtocolWifi: obciProtocolWifi
 };
+module.exports = constantsModule;
 
 /**
 * @description To add a usability abstraction layer above channel setting commands. Due to the
@@ -1525,6 +1527,25 @@ function channelSettingsObjectDefault (channelNumber) {
     bias: true,
     srb2: true,
     srb1: false
+  };
+}
+
+/**
+ * @description RawDataToSample default object creation
+ * @param numChannels {Number} - The number of channels
+ * @returns {RawDataToSample} - A new object
+ */
+function rawDataToSampleObjectDefault (numChannels) {
+  if (_.isUndefined(numChannels)) numChannels = obciNumberOfChannelsDefault;
+  return {
+    accelArray: [0, 0, 0],
+    channelSettings: constantsModule.channelSettingsArrayInit(numChannels),
+    lastSampleNumber: 0,
+    rawDataPacket: Buffer.alloc(33),
+    rawDataPackets: [],
+    scale: true,
+    timeOffset: 0,
+    verbose: false
   };
 }
 

--- a/openBCIUtilities.js
+++ b/openBCIUtilities.js
@@ -937,10 +937,19 @@ function transformRawDataPacketToSample (o) {
         break;
       default:
         // Don't do anything if the packet is not defined
+        const msg = `bad stop byte ${o.rawDataPacket[k.OBCIPacketPositionStopByte].toString('hex')}`;
+        sample = {
+          error: msg,
+          valid: false,
+          rawDataPacket: o.rawDataPacket
+        };
+        if (o.verbose) console.log();
         break;
     }
   } catch (err) {
     sample = {
+      error: err,
+      valid: false,
       rawDataPacket: o.rawDataPacket
     };
     if (o.verbose) console.log(err);
@@ -987,6 +996,8 @@ function parsePacketStandardAccel (o) {
   // Get the stop byte
   sampleObject.stopByte = o.rawDataPacket[k.OBCIPacketPositionStopByte];
 
+  sampleObject.valid = true;
+
   return sampleObject;
 }
 
@@ -1029,6 +1040,8 @@ function parsePacketStandardRawAux (o) {
   sampleObject.startByte = o.rawDataPacket[0];
   // Get the stop byte
   sampleObject.stopByte = o.rawDataPacket[k.OBCIPacketPositionStopByte];
+
+  sampleObject.valid = true;
 
   return sampleObject;
 }
@@ -1084,6 +1097,8 @@ function parsePacketTimeSyncedAccel (o) {
   if (o.scale) sampleObject.channelData = getChannelDataArray(o);
   else sampleObject.channelDataCounts = getChannelDataArrayNoScale(o.rawDataPacket);
 
+  sampleObject.valid = true;
+
   return sampleObject;
 }
 
@@ -1130,6 +1145,8 @@ function parsePacketTimeSyncedRawAux (o) {
   if (k.isUndefined(o.scale) || k.isNull(o.scale)) o.scale = true;
   if (o.scale) sampleObject.channelData = getChannelDataArray(o);
   else sampleObject.channelDataCounts = getChannelDataArrayNoScale(o.rawDataPacket);
+
+  sampleObject.valid = true;
 
   return sampleObject;
 }

--- a/openBCIUtilities.js
+++ b/openBCIUtilities.js
@@ -938,7 +938,7 @@ function transformRawDataPacketToSample (o) {
       default:
         // Don't do anything if the packet is not defined
         sample = {
-          error: `bad stop byte ${o.rawDataPacket.slice(32,33).toString('hex')}`,
+          error: `bad stop byte ${o.rawDataPacket.slice(32, 33).toString('hex')}`,
           valid: false,
           rawDataPacket: o.rawDataPacket
         };

--- a/openBCIUtilities.js
+++ b/openBCIUtilities.js
@@ -917,9 +917,9 @@ function transformRawDataPacketsToSample (o) {
  * @author AJ Keller (@pushtheworldllc)
  */
 function transformRawDataPacketToSample (o) {
-  const packetType = getRawPacketType(o.rawDataPacket[k.OBCIPacketPositionStopByte]);
   let sample;
   try {
+    const packetType = getRawPacketType(o.rawDataPacket[k.OBCIPacketPositionStopByte]);
     switch (packetType) {
       case k.OBCIStreamPacketStandardAccel:
         sample = utilitiesModule.parsePacketStandardAccel(o);
@@ -937,13 +937,12 @@ function transformRawDataPacketToSample (o) {
         break;
       default:
         // Don't do anything if the packet is not defined
-        const msg = `bad stop byte ${o.rawDataPacket[k.OBCIPacketPositionStopByte].toString('hex')}`;
         sample = {
-          error: msg,
+          error: `bad stop byte ${o.rawDataPacket.slice(32,33).toString('hex')}`,
           valid: false,
           rawDataPacket: o.rawDataPacket
         };
-        if (o.verbose) console.log();
+        if (o.verbose) console.log(sample.error);
         break;
     }
   } catch (err) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openbci-utilities",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "The official utility package of Node.js SDK for the OpenBCI Biosensor Boards.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "openbci-utilities",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "The official utility package of Node.js SDK for the OpenBCI Biosensor Boards.",
   "main": "index.js",
   "scripts": {
-    "test": "semistandard | snazzy && mocha test",
+    "test": "mocha test",
+    "test-lint": "semistandard | snazzy",
     "test-cov": "istanbul cover ./node_modules/mocha/bin/_mocha -- -R spec && codecov"
   },
   "keywords": [

--- a/test/openBCIConstants-test.js
+++ b/test/openBCIConstants-test.js
@@ -969,16 +969,16 @@ describe('OpenBCIConstants', function () {
   });
   describe('Board Types', function () {
     it('should get right name for chan daisy', function () {
-      expect(k.OBCIBoardDaisy).to.equal("daisy");
+      expect(k.OBCIBoardDaisy).to.equal('daisy');
     });
     it('should get right name for chan cyton', function () {
-      expect(k.OBCIBoardCyton).to.equal("cyton");
+      expect(k.OBCIBoardCyton).to.equal('cyton');
     });
     it('should get right name for chan ganglion', function () {
-      expect(k.OBCIBoardGanglion).to.equal("ganglion");
+      expect(k.OBCIBoardGanglion).to.equal('ganglion');
     });
     it('should get right name for chan none', function () {
-      expect(k.OBCIBoardNone).to.equal("none");
+      expect(k.OBCIBoardNone).to.equal('none');
     });
   });
   describe('numberOfChannelsForBoardTypes', function () {

--- a/test/openBCIUtilities-test.js
+++ b/test/openBCIUtilities-test.js
@@ -2120,6 +2120,7 @@ describe('#transformRawDataPacketToSample', function () {
 
     // Call the function under test
     openBCIUtilities.transformRawDataPacketToSample({
+      channelSettings: defaultChannelSettingsArray,
       rawDataPacket: buffer
     });
 
@@ -2131,6 +2132,7 @@ describe('#transformRawDataPacketToSample', function () {
 
     // Call the function under test
     openBCIUtilities.transformRawDataPacketToSample({
+      channelSettings: defaultChannelSettingsArray,
       rawDataPacket: buffer
     });
 
@@ -2140,22 +2142,46 @@ describe('#transformRawDataPacketToSample', function () {
     expect(funcSpyTimeSyncedAccel).to.not.have.been.called();
     expect(funcSpyTimeSyncedRawAux).to.not.have.been.called();
   });
+  it('should throw err when no channel settings', function () {
+    var buffer = new Buffer(5).fill(0)
+
+    // Call the function under test
+    let sample = openBCIUtilities.transformRawDataPacketToSample({
+      rawDataPacket: buffer
+    });
+
+    expect(sample.valid).to.be.false();
+    expect(sample.error.message).to.equal(k.OBCIErrorInvalidByteLength);
+    expect(bufferEqual(buffer, sample.rawDataPacket)).to.be.true();
+  });
   it('should process a time sync set packet with accel', function () {
     var buffer = openBCIUtilities.samplePacketAccelTimeSyncSet();
 
     // Call the function under test
     openBCIUtilities.transformRawDataPacketToSample({
+      channelSettings: defaultChannelSettingsArray,
       rawDataPacket: buffer
     });
 
     // we should call to get a packet
     expect(funcSpyTimeSyncedAccel).to.have.been.calledOnce();
   });
+  it('should process bad one', function () {
+    var buffer = openBCIUtilities.samplePacketRawAuxTimeSyncSet(0);
+    buffer.writeUInt8(215, k.OBCIPacketPositionStopByte);
+
+    // Call the function under test
+    openBCIUtilities.transformRawDataPacketToSample({
+      channelSettings: defaultChannelSettingsArray,
+      rawDataPacket: buffer
+    });
+  });
   it('should process a time synced packet with accel', function () {
     var buffer = openBCIUtilities.samplePacketAccelTimeSynced(0);
 
     // Call the function under test
     openBCIUtilities.transformRawDataPacketToSample({
+      channelSettings: defaultChannelSettingsArray,
       rawDataPacket: buffer
     });
 
@@ -2167,6 +2193,7 @@ describe('#transformRawDataPacketToSample', function () {
 
     // Call the function under test
     openBCIUtilities.transformRawDataPacketToSample({
+      channelSettings: defaultChannelSettingsArray,
       rawDataPacket: buffer
     });
 
@@ -2177,6 +2204,7 @@ describe('#transformRawDataPacketToSample', function () {
 
     // Call the function under test
     openBCIUtilities.transformRawDataPacketToSample({
+      channelSettings: defaultChannelSettingsArray,
       rawDataPacket: buffer
     });
 
@@ -2191,6 +2219,7 @@ describe('#transformRawDataPacketToSample', function () {
 
     // Call the function under test
     openBCIUtilities.transformRawDataPacketToSample({
+      channelSettings: defaultChannelSettingsArray,
       rawDataPacket: buffer
     });
 

--- a/test/openBCIUtilities-test.js
+++ b/test/openBCIUtilities-test.js
@@ -2143,7 +2143,7 @@ describe('#transformRawDataPacketToSample', function () {
     expect(funcSpyTimeSyncedRawAux).to.not.have.been.called();
   });
   it('should throw err when no channel settings', function () {
-    var buffer = new Buffer(5).fill(0)
+    var buffer = new Buffer(5).fill(0);
 
     // Call the function under test
     let sample = openBCIUtilities.transformRawDataPacketToSample({


### PR DESCRIPTION
# 0.0.7

### Continuous Integration

* Add `npm run test-lint` to add linting to travis.yml

### Bug Fixes

* Last sample number was confusing to use with `transformRawDataPacketsToSample`

### New Features

* In openBCIUtilities.js add function `transformRawDataPacketToSample` to parse a single raw data packet
* In openBCIConstants.js add function `rawDataToSampleObjectDefault(numChannels)` which should be used by drivers to create the object that is passed through each call to `transformRawDataPacketsToSample` 
