### PR TITLE
v0.1.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# 0.0.11
+
+### New Functions
+
+* Add functions to help determine the board firmware version
+
 # 0.0.10
 
 ### New Function

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,12 @@
-# 0.0.11
+# 0.1.0
 
 ### New Functions
 
-* Add functions to help determine the board firmware version
+* Add function `getFirmware(dataBuffer)` to utilities 
+
+### Breaking Changes
+
+* Removed function called `findV2Firmware()` because it's useless with v3.0.0 firmware
 
 # 0.0.10
 

--- a/openBCIUtilities.js
+++ b/openBCIUtilities.js
@@ -555,8 +555,7 @@ var utilitiesModule = {
   isOdd,
   countADSPresent,
   doesBufferHaveEOT,
-  findV2Firmware,
-  getMajorFirmwareVersion,
+  getFirmware,
   isFailureInBuffer,
   isSuccessInBuffer,
   isTimeSyncSetConfirmationInBuffer,
@@ -1604,28 +1603,21 @@ function doesBufferHaveEOT (dataBuffer) {
 }
 
 /**
-* @description Used to parse a soft reset response to determine if the board is running the v2 firmware
-* @param dataBuffer {Buffer} - The data to parse
-* @returns {boolean} - True if `v2`is indeed found in the `dataBuffer`
-*/
-function findV2Firmware (dataBuffer) {
-  const s = new StreamSearch(new Buffer(k.OBCIParseFirmware));
-
-  // Clear the buffer
-  s.reset();
-
-  // Push the new data buffer. This runs the search.
-  s.push(dataBuffer);
-
-  // Check and see if there is a match
-  return s.matches >= 1;
-}
-
-function getMajorFirmwareVersion (dataBuffer) {
-  const regexPattern = /v\d/;
+ * Used to extract the major version from
+ * @param dataBuffer
+ * @return {*}
+ */
+function getFirmware (dataBuffer) {
+  const regexPattern = /v\d.\d.\d/;
   const ret = dataBuffer.toString().match(regexPattern);
-  if (ret) return ret[0];
-  else return ret;
+  if (ret) {
+    const elems = ret[0].split('.');
+    return {
+      major: Number(elems[0][1]),
+      minor: Number(elems[1]),
+      patch: Number(elems[2])
+    };
+  } else return ret;
 }
 
 /**

--- a/openBCIUtilities.js
+++ b/openBCIUtilities.js
@@ -556,6 +556,7 @@ var utilitiesModule = {
   countADSPresent,
   doesBufferHaveEOT,
   findV2Firmware,
+  getMajorFirmwareVersion,
   isFailureInBuffer,
   isSuccessInBuffer,
   isTimeSyncSetConfirmationInBuffer,
@@ -1618,6 +1619,13 @@ function findV2Firmware (dataBuffer) {
 
   // Check and see if there is a match
   return s.matches >= 1;
+}
+
+function getMajorFirmwareVersion (dataBuffer) {
+  const regexPattern = /v\d/;
+  const ret = dataBuffer.toString().match(regexPattern);
+  if (ret) return ret[0];
+  else return ret;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openbci-utilities",
-  "version": "0.0.10",
+  "version": "0.1.0",
   "description": "The official utility package of Node.js SDK for the OpenBCI Biosensor Boards.",
   "main": "index.js",
   "scripts": {

--- a/test/openBCIUtilities-test.js
+++ b/test/openBCIUtilities-test.js
@@ -1328,14 +1328,14 @@ $$$`);
     it('should not find any v2', function () {
       let buf = new Buffer('AJ Keller is an awesome programmer!\n I know right!');
 
-      expect(openBCIUtilities.getFirmware(buf)).to.equal(null)
+      expect(openBCIUtilities.getFirmware(buf)).to.equal(null);
     });
     it('should not find a v2', function () {
       let buf = new Buffer(`OpenBCI V3 Simulator
 On Board ADS1299 Device ID: 0x12345
 LIS3DH Device ID: 0x38422$$$`);
 
-      expect(openBCIUtilities.getFirmware(buf)).to.equal(null)
+      expect(openBCIUtilities.getFirmware(buf)).to.equal(null);
     });
     it('should find a v2', function () {
       let buf = new Buffer(`OpenBCI V3 Simulator

--- a/test/openBCIUtilities-test.js
+++ b/test/openBCIUtilities-test.js
@@ -1342,10 +1342,49 @@ LIS3DH Device ID: 0x38422$$$`);
 On Board ADS1299 Device ID: 0x12345
 On Daisy ADS1299 Device ID: 0xFFFFF
 LIS3DH Device ID: 0x38422
-Firmware: v2
+Firmware: v2.0.0
 $$$`);
 
       expect(openBCIUtilities.findV2Firmware(buf)).to.equal(true);
+    });
+  });
+  describe('#getMajorFirmwareVersion', function () {
+    it('should not crash on small buff', function () {
+      let buf = new Buffer('AJ!');
+
+      expect(openBCIUtilities.getMajorFirmwareVersion(buf)).to.equal(null);
+    });
+    it('should not find any v2', function () {
+      let buf = new Buffer('AJ Keller is an awesome programmer!\n I know right!');
+
+      expect(openBCIUtilities.getMajorFirmwareVersion(buf)).to.equal(null)
+    });
+    it('should not find a v2', function () {
+      let buf = new Buffer(`OpenBCI V3 Simulator
+On Board ADS1299 Device ID: 0x12345
+LIS3DH Device ID: 0x38422$$$`);
+
+      expect(openBCIUtilities.getMajorFirmwareVersion(buf)).to.equal(null)
+    });
+    it('should find a v2', function () {
+      let buf = new Buffer(`OpenBCI V3 Simulator
+On Board ADS1299 Device ID: 0x12345
+On Daisy ADS1299 Device ID: 0xFFFFF
+LIS3DH Device ID: 0x38422
+Firmware: v2.0.0
+$$$`);
+
+      expect(openBCIUtilities.getMajorFirmwareVersion(buf)).to.equal('v2');
+    });
+    it('should find a v3', function () {
+      let buf = new Buffer(`OpenBCI V3 Simulator
+On Board ADS1299 Device ID: 0x12345
+On Daisy ADS1299 Device ID: 0xFFFFF
+LIS3DH Device ID: 0x38422
+Firmware: v3.0.0
+$$$`);
+
+      expect(openBCIUtilities.getMajorFirmwareVersion(buf)).to.equal('v3');
     });
   });
   describe('#isFailureInBuffer', function () {

--- a/test/openBCIUtilities-test.js
+++ b/test/openBCIUtilities-test.js
@@ -1319,72 +1319,51 @@ $$$`);
       expect(openBCIUtilities.doesBufferHaveEOT(buf)).to.equal(true);
     });
   });
-  describe('#findV2Firmware', function () {
-    it('should not crash on small buff', function () {
-      let buf = new Buffer('AJ!');
-
-      expect(openBCIUtilities.findV2Firmware(buf)).to.be.false();
-    });
-    it('should not find any v2', function () {
-      let buf = new Buffer('AJ Keller is an awesome programmer!\n I know right!');
-
-      expect(openBCIUtilities.findV2Firmware(buf)).to.be.false();
-    });
-    it('should not find a v2', function () {
-      let buf = new Buffer(`OpenBCI V3 Simulator
-On Board ADS1299 Device ID: 0x12345
-LIS3DH Device ID: 0x38422$$$`);
-
-      expect(openBCIUtilities.findV2Firmware(buf)).to.be.false();
-    });
-    it('should find a v2', function () {
-      let buf = new Buffer(`OpenBCI V3 Simulator
-On Board ADS1299 Device ID: 0x12345
-On Daisy ADS1299 Device ID: 0xFFFFF
-LIS3DH Device ID: 0x38422
-Firmware: v2.0.0
-$$$`);
-
-      expect(openBCIUtilities.findV2Firmware(buf)).to.equal(true);
-    });
-  });
   describe('#getMajorFirmwareVersion', function () {
     it('should not crash on small buff', function () {
       let buf = new Buffer('AJ!');
 
-      expect(openBCIUtilities.getMajorFirmwareVersion(buf)).to.equal(null);
+      expect(openBCIUtilities.getFirmware(buf)).to.equal(null);
     });
     it('should not find any v2', function () {
       let buf = new Buffer('AJ Keller is an awesome programmer!\n I know right!');
 
-      expect(openBCIUtilities.getMajorFirmwareVersion(buf)).to.equal(null)
+      expect(openBCIUtilities.getFirmware(buf)).to.equal(null)
     });
     it('should not find a v2', function () {
       let buf = new Buffer(`OpenBCI V3 Simulator
 On Board ADS1299 Device ID: 0x12345
 LIS3DH Device ID: 0x38422$$$`);
 
-      expect(openBCIUtilities.getMajorFirmwareVersion(buf)).to.equal(null)
+      expect(openBCIUtilities.getFirmware(buf)).to.equal(null)
     });
     it('should find a v2', function () {
       let buf = new Buffer(`OpenBCI V3 Simulator
 On Board ADS1299 Device ID: 0x12345
 On Daisy ADS1299 Device ID: 0xFFFFF
 LIS3DH Device ID: 0x38422
-Firmware: v2.0.0
+Firmware: v2.0.1
 $$$`);
 
-      expect(openBCIUtilities.getMajorFirmwareVersion(buf)).to.equal('v2');
+      expect(openBCIUtilities.getFirmware(buf)).to.deep.equal({
+        major: 2,
+        minor: 0,
+        patch: 1
+      });
     });
     it('should find a v3', function () {
       let buf = new Buffer(`OpenBCI V3 Simulator
 On Board ADS1299 Device ID: 0x12345
 On Daisy ADS1299 Device ID: 0xFFFFF
 LIS3DH Device ID: 0x38422
-Firmware: v3.0.0
+Firmware: v3.0.1
 $$$`);
 
-      expect(openBCIUtilities.getMajorFirmwareVersion(buf)).to.equal('v3');
+      expect(openBCIUtilities.getFirmware(buf)).to.deep.equal({
+        major: 3,
+        minor: 0,
+        patch: 1
+      });
     });
   });
   describe('#isFailureInBuffer', function () {


### PR DESCRIPTION
# 0.1.0

### New Functions

* Add function `getFirmware(dataBuffer)` to utilities 

### Breaking Changes

* Removed function called `findV2Firmware()` because it's useless with v3.0.0 firmware
