### PR TITLE
FIX: Sample objects were inconsistent and closes #147

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+# 0.1.2
+
+### Bug Fixes
+
+* Send counts did not work for daisy.
+* Sample output was inconsistent
+* Fixed `timeStamp` to `timestamp` this was pr #147 (thanks @alexdevmotion)
+
 # 0.1.1
 
 ### Bug Fixes

--- a/openBCIUtilities.js
+++ b/openBCIUtilities.js
@@ -1045,6 +1045,9 @@ function parsePacketStandardAccel (o) {
 
   sampleObject.valid = true;
 
+  sampleObject.timestamp = Date.now();
+  sampleObject.boardTime = 0;
+
   return sampleObject;
 }
 
@@ -1090,6 +1093,9 @@ function parsePacketStandardRawAux (o) {
 
   sampleObject.valid = true;
 
+  sampleObject.timestamp = Date.now();
+  sampleObject.boardTime = 0;
+
   return sampleObject;
 }
 
@@ -1130,7 +1136,11 @@ function parsePacketTimeSyncedAccel (o) {
 
   // Get the board time
   sampleObject.boardTime = getFromTimePacketTime(o.rawDataPacket);
-  sampleObject.timeStamp = sampleObject.boardTime + o.timeOffset;
+  if (o.hasOwnProperty('timeOffset')) {
+    sampleObject.timestamp = sampleObject.boardTime + o.timeOffset;
+  } else {
+    sampleObject.timestamp = Date.now();
+  }
 
   // Extract the aux data
   sampleObject.auxData = getFromTimePacketRawAux(o.rawDataPacket);
@@ -1183,7 +1193,11 @@ function parsePacketTimeSyncedRawAux (o) {
 
   // Get the board time
   sampleObject.boardTime = getFromTimePacketTime(o.rawDataPacket);
-  sampleObject.timeStamp = sampleObject.boardTime + o.timeOffset;
+  if (o.hasOwnProperty('timeOffset')) {
+    sampleObject.timestamp = sampleObject.boardTime + o.timeOffset;
+  } else {
+    sampleObject.timestamp = Date.now();
+  }
 
   // Extract the aux data
   sampleObject.auxData = getFromTimePacketRawAux(o.rawDataPacket);
@@ -1403,7 +1417,7 @@ function newSample (sampleNumber) {
     auxData: null,
     stopByte: k.OBCIByteStop,
     boardTime: 0,
-    timeStamp: 0
+    timestamp: 0
   };
 }
 
@@ -1496,6 +1510,8 @@ function makeDaisySampleObject (lowerSampleObject, upperSampleObject) {
     daisySampleObject['accelData'] = upperSampleObject.accelData;
   }
 
+  daisySampleObject['valid'] = true;
+
   return daisySampleObject;
 }
 
@@ -1546,6 +1562,8 @@ function makeDaisySampleObjectWifi (lowerSampleObject, upperSampleObject) {
   } else if (upperSampleObject.accelData) {
     daisySampleObject['accelData'] = upperSampleObject.accelData;
   }
+
+  daisySampleObject['valid'] = true;
 
   return daisySampleObject;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openbci-utilities",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "The official utility package of Node.js SDK for the OpenBCI Biosensor Boards.",
   "main": "index.js",
   "scripts": {

--- a/test/openBCIUtilities-test.js
+++ b/test/openBCIUtilities-test.js
@@ -55,6 +55,14 @@ describe('openBCIUtilities', function () {
 
       expect(sample.sampleNumber).to.equal(0x45);
     });
+    it('should be valid', function () {
+      let sample = openBCIUtilities.parsePacketStandardAccel({
+        rawDataPacket: sampleBuf,
+        channelSettings: defaultChannelSettingsArray,
+        scale: true
+      });
+      expect(sample.valid).to.be.true();
+    });
     it('all the channels should have the same number value as their (index + 1) * scaleFactor', function () {
       // sampleBuf has its channel number for each 3 byte integer. See line 20...
       let sample = openBCIUtilities.parsePacketStandardAccel({
@@ -137,6 +145,23 @@ describe('openBCIUtilities', function () {
         expect(sample.sampleNumber).to.equal(samplesReceived);
         samplesReceived++;
       }
+    });
+    it('should be have time stamp when none given', function () {
+      let sample = openBCIUtilities.parsePacketStandardAccel({
+        rawDataPacket: sampleBuf,
+        channelSettings: defaultChannelSettingsArray,
+        scale: true
+      });
+      expect(sample.boardTime).to.equal(0);
+      expect(sample.timestamp).to.be.greaterThan(0);
+    });
+    it('should be valid', function () {
+      let sample = openBCIUtilities.parsePacketStandardAccel({
+        rawDataPacket: sampleBuf,
+        channelSettings: defaultChannelSettingsArray,
+        scale: true
+      });
+      expect(sample.valid).to.be.true();
     });
     it('has the right sample number', function () {
       let expectedSampleNumber = 0x45;
@@ -245,6 +270,25 @@ describe('openBCIUtilities', function () {
         scale: true
       });
       expect(sample.sampleNumber).to.equal(expectedSampleNumber);
+    });
+    it('should be valid', function () {
+      packet = openBCIUtilities.samplePacketStandardRawAux(0);
+      let sample = openBCIUtilities.parsePacketStandardRawAux({
+        rawDataPacket: packet,
+        channelSettings: defaultChannelSettingsArray,
+        scale: true
+      });
+      expect(sample.valid).to.be.true();
+    });
+    it('should be have time stamp when none given', function () {
+      packet = openBCIUtilities.samplePacketStandardRawAux(0);
+      let sample = openBCIUtilities.parsePacketStandardRawAux({
+        rawDataPacket: packet,
+        channelSettings: defaultChannelSettingsArray,
+        scale: true
+      });
+      expect(sample.boardTime).to.equal(0);
+      expect(sample.timestamp).to.be.greaterThan(0);
     });
     it('has the right stop byte', function () {
       packet = openBCIUtilities.samplePacketStandardRawAux(0);
@@ -423,6 +467,25 @@ describe('openBCIUtilities', function () {
         expect(channelValue).to.equal(index + 1);
       });
     });
+    it('should be have time stamp when none given', function () {
+      packet1 = openBCIUtilities.samplePacketAccelTimeSynced(0);
+      let sample = openBCIUtilities.parsePacketTimeSyncedAccel({
+        rawDataPacket: packet1,
+        channelSettings: defaultChannelSettingsArray,
+        scale: true
+      });
+      expect(sample.boardTime).to.equal(1);
+      expect(sample.timestamp).to.be.greaterThan(0);
+    });
+    it('should be valid', function () {
+      packet1 = openBCIUtilities.samplePacketAccelTimeSynced(0);
+      let sample = openBCIUtilities.parsePacketTimeSyncedAccel({
+        rawDataPacket: packet1,
+        channelSettings: defaultChannelSettingsArray,
+        scale: true
+      });
+      expect(sample.valid).to.be.true();
+    });
     it('has the right sample number', function () {
       let expectedSampleNumber = 69;
       packet1 = openBCIUtilities.samplePacketAccelTimeSynced(expectedSampleNumber);
@@ -518,6 +581,25 @@ describe('openBCIUtilities', function () {
       sample.channelDataCounts.forEach((channelValue, index) => {
         expect(channelValue).to.equal(index + 1);
       });
+    });
+    it('should be valid', function () {
+      packet = openBCIUtilities.samplePacketRawAuxTimeSynced(0);
+      let sample = openBCIUtilities.parsePacketTimeSyncedRawAux({
+        rawDataPacket: packet,
+        channelSettings: defaultChannelSettingsArray,
+        scale: true
+      });
+      expect(sample.valid).to.be.true();
+    });
+    it('should be have time stamp when none given', function () {
+      packet = openBCIUtilities.samplePacketRawAuxTimeSynced(0);
+      let sample = openBCIUtilities.parsePacketTimeSyncedRawAux({
+        rawDataPacket: packet,
+        channelSettings: defaultChannelSettingsArray,
+        scale: true
+      });
+      expect(sample.boardTime).to.equal(1);
+      expect(sample.timestamp).to.be.greaterThan(0);
     });
     it('has the right sample number', function () {
       let expectedSampleNumber = 69;
@@ -689,8 +771,8 @@ describe('openBCIUtilities', function () {
         timeOffset: timeOffset,
         accelArray
       });
-      expect(sample.timeStamp).to.exist();
-      expect(sample.timeStamp).to.equal(time + timeOffset);
+      expect(sample.timestamp).to.exist();
+      expect(sample.timestamp).to.equal(time + timeOffset);
     });
   });
   describe('#convertSampleToPacketRawAuxTimeSynced', function () {
@@ -755,8 +837,8 @@ describe('openBCIUtilities', function () {
         timeOffset: timeOffset,
         scale: false
       });
-      expect(sample.timeStamp).to.exist();
-      expect(sample.timeStamp).to.equal(time + timeOffset);
+      expect(sample.timestamp).to.exist();
+      expect(sample.timestamp).to.equal(time + timeOffset);
     });
   });
   describe('#interpret24bitAsInt32', function () {
@@ -947,6 +1029,10 @@ describe('openBCIUtilities', function () {
       // Call the function under test
       daisySampleObjectNoScale = openBCIUtilities.makeDaisySampleObject(lowerSampleObjectNoScale, upperSampleObjectNoScale);
     });
+    it('should have valid object true', function () {
+      expect(daisySampleObject.valid).to.be.true();
+      expect(daisySampleObjectNoScale.valid).to.be.true();
+    });
     it('should make a channelData array 16 elements long', function () {
       expect(daisySampleObject.channelData).to.have.length(k.OBCINumberOfChannelsDaisy);
       expect(daisySampleObjectNoScale.channelDataCounts).to.have.length(k.OBCINumberOfChannelsDaisy);
@@ -1023,6 +1109,10 @@ describe('openBCIUtilities', function () {
 
       // Call the function under test
       daisySampleObjectNoScale = openBCIUtilities.makeDaisySampleObjectWifi(lowerSampleObjectNoScale, upperSampleObjectNoScale);
+    });
+    it('should have valid object true', function () {
+      expect(daisySampleObject.valid).to.be.true();
+      expect(daisySampleObjectNoScale.valid).to.be.true();
     });
     it('should make a channelData array 16 elements long', function () {
       expect(daisySampleObject.channelData).to.have.length(k.OBCINumberOfChannelsDaisy);


### PR DESCRIPTION
# 0.1.2

### Bug Fixes

* Send counts did not work for daisy.
* Sample output was inconsistent
* Fixed `timeStamp` to `timestamp` this was pr #147 (thanks @alexdevmotion)
