### PR TITLE
ADD: Stop byte property to daisy samples

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# v0.2.7
+
+### Bug Fixes
+
+* No `stopByte` property for daisy samples. Added tests.
+
 # v0.2.6
 
 ### Bug Fixes

--- a/openBCIUtilities.js
+++ b/openBCIUtilities.js
@@ -1803,6 +1803,8 @@ function makeDaisySampleObject (lowerSampleObject, upperSampleObject) {
     'upper': upperSampleObject.auxData
   };
 
+  daisySampleObject.stopByte = lowerSampleObject.stopByte;
+
   daisySampleObject.timestamp = (lowerSampleObject.timestamp + upperSampleObject.timestamp) / 2;
 
   daisySampleObject['_timestamps'] = {
@@ -1867,6 +1869,8 @@ function makeDaisySampleObjectWifi (lowerSampleObject, upperSampleObject) {
   if (lowerSampleObject.hasOwnProperty('timestamp')) {
     daisySampleObject['timestamp'] = lowerSampleObject.timestamp;
   }
+
+  daisySampleObject.stopByte = lowerSampleObject.stopByte;
 
   daisySampleObject['_timestamps'] = {
     'lower': lowerSampleObject.timestamp,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openbci-utilities",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "The official utility package of Node.js SDK for the OpenBCI Biosensor Boards.",
   "main": "index.js",
   "scripts": {

--- a/test/openBCIUtilities-test.js
+++ b/test/openBCIUtilities-test.js
@@ -1628,6 +1628,10 @@ describe('openBCIUtilities', function () {
         expect(daisySampleObjectNoScale.auxData['upper'][i]).to.equal(i + 3);
       }
     });
+    it('should take the lower stopByte', function () {
+      expect(daisySampleObject.stopByte).to.equal(lowerSampleObject.stopByte);
+      expect(daisySampleObjectNoScale.stopByte).to.equal(lowerSampleObjectNoScale.stopByte);
+    });
     it('should average the two timestamps together', function () {
       let expectedAverage = (upperSampleObject.timestamp + lowerSampleObject.timestamp) / 2;
       expect(daisySampleObject.timestamp).to.equal(expectedAverage);
@@ -1733,7 +1737,11 @@ describe('openBCIUtilities', function () {
     });
     it('should take the lower timestamp', function () {
       expect(daisySampleObject.timestamp).to.equal(lowerSampleObject.timestamp);
-      expect(daisySampleObjectNoScale.timestamp).to.equal(lowerSampleObject.timestamp);
+      expect(daisySampleObjectNoScale.timestamp).to.equal(lowerSampleObjectNoScale.timestamp);
+    });
+    it('should take the lower stopByte', function () {
+      expect(daisySampleObject.stopByte).to.equal(lowerSampleObject.stopByte);
+      expect(daisySampleObjectNoScale.stopByte).to.equal(lowerSampleObjectNoScale.stopByte);
     });
     it('should place the old timestamps in an object', function () {
       expect(daisySampleObject._timestamps.lower).to.equal(lowerSampleObject.timestamp);


### PR DESCRIPTION
# v0.2.7

### Bug Fixes

* No `stopByte` property for daisy samples. Added tests.